### PR TITLE
Fix quadratic scaling in circuit printing

### DIFF
--- a/src/pyLIQTR/QSP/qsp_helpers.py
+++ b/src/pyLIQTR/QSP/qsp_helpers.py
@@ -72,11 +72,7 @@ def print_to_openqasm(f,circuit,print_header=True,qubits=None):
     Frustratingly required because of circ very 'kindly' converting ccz/ccx/cz/X^1/T for us...
     '''
     
-    def getOp(myIdx):
-        for idx,op in enumerate(circuit.all_operations()):
-            if myIdx == idx:
-                return op
-        return None
+    op_list = list(circuit.all_operations())
 
     gateCounter = -1
     myReg = None
@@ -117,7 +113,7 @@ def print_to_openqasm(f,circuit,print_header=True,qubits=None):
             #get gate
             gateCounter += 1
             skipLines = True
-            op = getOp(gateCounter)
+            op = op_list[gateCounter]
             #fix the damn line
             ogline = str(op)
             


### PR DESCRIPTION
The current version of the qasm printing helper function has a quadratic scaling because it is iterating over the circuit every time an operation is called.  By instead storing the operations as a list at the beginning of the function, this allows for instantaneous lookup while retaining the same functionality.

This is largely untested as a fix beyond viewing the file size and structure of the files, so please exercise caution before merging.  The output from the circuit generators seems to be non-deterministic and when I tried reading the file into cirq by reading the file and translating the string to cirq, I get an error `QasmException: Unknown gate "reset" at line 7`.  I tried finding a built in circuit reader in case I was making a mistake, but couldn't find one.