### PR TITLE
Merge 9-fix_prepare_gate_comparison to main

### DIFF
--- a/src/pyLIQTR/circuits/operators/prepare.py
+++ b/src/pyLIQTR/circuits/operators/prepare.py
@@ -95,6 +95,8 @@ class Prepare(pyLOperator):
         return self.disentangle_recursive(alt=False, flip=True, pp_tgt=self.pp_exp, pp_com=self.pp_com, pp_ctl=self.pp_ctl)
 
     def __eq__(self,other):
+        if not hasattr(other,'total_decomp'):
+            return False
         return (self.total_decomp == other.total_decomp) and (self.__class__ == other.__class__)
 
     def alpha_prep(self, flip: bool, alpha_pair:Tuple[float, float]):

--- a/src/pyLIQTR/circuits/operators/tests/test_prepare.py
+++ b/src/pyLIQTR/circuits/operators/tests/test_prepare.py
@@ -13,7 +13,7 @@ def get_common_gate_ops() -> List[cirq.GateOperation]:
     ops = []
     for gate_name in gate_names:
         # Gate class and gate's required num of qubits
-        clss = getattr(cirq,gate)
+        clss = getattr(cirq,gate_name)
         num_q = clss.num_qubits()
 
         # Create gate operation and store in list of ops

--- a/src/pyLIQTR/circuits/operators/tests/test_prepare.py
+++ b/src/pyLIQTR/circuits/operators/tests/test_prepare.py
@@ -1,0 +1,36 @@
+import inspect
+from typing import List
+import pytest
+import cirq
+
+import pyLIQTR.circuits.operators.prepare as prep
+
+def get_common_gate_ops() -> List[cirq.GateOperation]:
+    """Generate a list of GateOperations from cirq's list of common ops."""
+    # Get cirq's common gate names
+    gate_names = [name for name,c  in inspect.getmembers(cirq) if isinstance(c,cirq.Gate)]
+
+    ops = []
+    for gate_name in gate_names:
+        # Gate class and gate's required num of qubits
+        clss = getattr(cirq,gate)
+        num_q = clss.num_qubits()
+
+        # Create gate operation and store in list of ops
+        ops.append(clss(*[cirq.LineQubit(i) for i in range(num_q)]))
+    return ops
+
+class TestPrepare:
+    @pytest.mark.parametrize("op", get_common_gate_ops())
+    def test_prepare_comparison_to_common_ops(self,op):
+        """Should be False when comparing the prepare operation to common cirq operations.
+
+        Tests issue #9.
+        """
+        # Create arbitrary prepare operation
+        qbs = [cirq.LineQubit(i) for i in range(2)]  # arbitrary
+        alphas = [.1,.2,.3,.4]  # arbitrary
+        op1 = prep.Prepare(qbs,alphas).on(*qbs)
+        op2 = op
+        assert op1 != op2
+

--- a/src/pyLIQTR/circuits/operators/tests/test_prepare.py
+++ b/src/pyLIQTR/circuits/operators/tests/test_prepare.py
@@ -5,32 +5,35 @@ import cirq
 
 import pyLIQTR.circuits.operators.prepare as prep
 
+
 def get_common_gate_ops() -> List[cirq.GateOperation]:
     """Generate a list of GateOperations from cirq's list of common ops."""
     # Get cirq's common gate names
-    gate_names = [name for name,c  in inspect.getmembers(cirq) if isinstance(c,cirq.Gate)]
+    gate_names = [
+        name for name, c in inspect.getmembers(cirq) if isinstance(c, cirq.Gate)
+    ]
 
     ops = []
     for gate_name in gate_names:
         # Gate class and gate's required num of qubits
-        clss = getattr(cirq,gate_name)
+        clss = getattr(cirq, gate_name)
         num_q = clss.num_qubits()
 
         # Create gate operation and store in list of ops
         ops.append(clss(*[cirq.LineQubit(i) for i in range(num_q)]))
     return ops
 
+
 class TestPrepare:
     @pytest.mark.parametrize("op", get_common_gate_ops())
-    def test_prepare_comparison_to_common_ops(self,op):
+    def test_prepare_comparison_to_common_ops(self, op):
         """Should be False when comparing the prepare operation to common cirq operations.
 
         Tests issue #9.
         """
         # Create arbitrary prepare operation
         qbs = [cirq.LineQubit(i) for i in range(2)]  # arbitrary
-        alphas = [.1,.2,.3,.4]  # arbitrary
-        op1 = prep.Prepare(qbs,alphas).on(*qbs)
+        alphas = [0.1, 0.2, 0.3, 0.4]  # arbitrary
+        op1 = prep.Prepare(qbs, alphas).on(*qbs)
         op2 = op
         assert op1 != op2
-


### PR DESCRIPTION
Addresses #9 

This PR includes:

1. Tests of `prepare.py` which creates common cirq gate operations and compares them with a `Prepare` gate operation. These tests fail with existing `Prepare` gates due to the error `<gate> object has no attribute 'total_decomp'` as mentioned in issue #9 
2. This adds a check for this attribute in the `Prepare` class. If `total_decomp` is missing in the object being compared to, equality returns False since a `Prepare` gate MUST have this attribute. If it is missing, then the object being compared to is NOT a `Prepare` gate. If `total_decomp` exists in object being compared to, equality check proceeds as done currently.