### PR TITLE
Remove Python version upper bound

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     author_email=AUTHOR_EMAIL,
     packages=find_packages(where="src"),
     package_dir={"": "src"},
-    python_requires=">=3.8,<=3.12",
+    python_requires=">=3.8",
     install_requires=REQUIREMENTS,
     extras_require={"dev": REQUIREMENTS_DEV},
 )


### PR DESCRIPTION
Enforcing an upper bound on `python_requires` in `setup.py` prohibits pyLIQTR from working with newer versions of Python.  For example, the current `<=3.12` prevents me from installing a recent pyLIQTR in my Python 3.12.3 installation.  The [Python Packaging User Guide](https://packaging.python.org/en/latest/guides/dropping-older-python-versions/) even cautions,
> Avoid adding upper bounds to the version ranges, e. g. ">= 3.8, < 3.10". Doing so can cause different errors and version conflicts. See the [discourse-discussion](https://discuss.python.org/t/requires-python-upper-limits/12663) for more information.

This pull request simply removes the upper bound on the Python version.