### PR TITLE
Fix signature of BlockEncoding_select_prepare

### DIFF
--- a/src/pyLIQTR/BlockEncodings/BlockEncoding.py
+++ b/src/pyLIQTR/BlockEncodings/BlockEncoding.py
@@ -127,8 +127,8 @@ class BlockEncoding_select_prepare(BlockEncoding):
     @property
     def signature(self):
         return qt._infra.registers.Signature(
-            [*self.control_registers, *self.selection_registers, 
-             *self.target_registers, *self.junk_registers] )
+            [*self.control_registers, *self.selection_registers,
+             *self.junk_registers, *self.target_registers] )
 
 
 


### PR DESCRIPTION
This PR fixes the signature of `BlockEncoding_select_prepare` by moving the target registers into the lowest-order bits.  This is needed when a block encoding is tensor-contracted into a unitary matrix, so that the original matrix will be placed correctly into the upper-left corner of the unitary.

